### PR TITLE
Fix handling of SDL events on Windows

### DIFF
--- a/src/sdl.cpp
+++ b/src/sdl.cpp
@@ -61,8 +61,6 @@ bool initGraphics(int frameWidth, int frameHeight)
 		printf("Cannot set video mode %dx%d - %s\n", frameWidth, frameHeight, SDL_GetError());
 		return false;
 	}
-	void handleUIThread(void);
-	sdlUIThread = std::thread(handleUIThread);
 	return true;
 }
 
@@ -192,11 +190,11 @@ void getSDLInputs(const Uint8*& keystate, int& mouseDeltaX, int& mouseDeltaY, st
 	eventLock.unlock();
 }
 
-// this thread is automatically run by initGraphics and supports early exit of the program
+// this is called by the main thread, processes window events and supports early exit of the program
 // by pressing the ESC key or closing the window using the "X" button. It also handles window
 // redraw events, the F12 key (for screenshots), and saves all other events ("non-system") to
 // a queue (savedEvents). The queue can be retrieved later (getSavedEvents)
-void handleUIThread()
+void uiMainLoop()
 {
 	SDL_Event ev;
 	while (!exitRequested && SDL_WaitEvent(&ev)) {
@@ -206,13 +204,6 @@ void handleUIThread()
 			eventLock.unlock();
 		}
 	}
-}
-
-/// waits the user to indicate he/she wants to close the application (by either clicking on the "X" of the window,
-/// or by pressing ESC). Since the actual event handling is done by the UI thread, we just wait for it to exit
-void waitForUserExit(void)
-{
-	sdlUIThread.join(); // wait for the message loop to close
 }
 
 /// checks if the user indicated he/she wants to close the application (by either clicking on the "X" of the window,

--- a/src/sdl.h
+++ b/src/sdl.h
@@ -46,7 +46,6 @@ extern bool isInteractive;
 bool initGraphics(int frameWidth, int frameHeight);
 void closeGraphics(void);
 void displayVFB(Color vfb[VFB_MAX_SIZE][VFB_MAX_SIZE]); //!< displays the VFB (Virtual framebuffer) to the real one.
-void waitForUserExit(void); //!< Pause. Wait until the user closes the application
 bool checkForUserExit(void); //!< check if the user wants to close the application (returns true if so)
 /**
  * Gets the keyboard, mouse and potentially other inputs from SDL:


### PR DESCRIPTION
* Migrate the handleUIThread() call to the main thread and migrate the logic for calling the rendering functions (or interactive loop) in a separate thread. This fixes the responsiveness of the windows by handling the window events in the main thread. It seemed like they were not handled when the loop was running on a separate thread.